### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Hacker News Companion MCP
 [![smithery badge](https://smithery.ai/badge/@georgeck/hn-companion-mcp)](https://smithery.ai/server/@georgeck/hn-companion-mcp)
 
+<a href="https://glama.ai/mcp/servers/@georgeck/hn-companion-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@georgeck/hn-companion-mcp/badge" alt="Hacker News Companion MCP server" />
+</a>
+
 A Model Context Protocol (MCP) for summarizing Hacker News discussions using Claude.
 
 ## Overview
@@ -104,7 +108,6 @@ Claude can call this MCP to get the formatted data and then generate a summary b
     }
   }
 ```
-
 
 ## License
 


### PR DESCRIPTION
This PR adds a badge for the [Hacker News Companion MCP](https://glama.ai/mcp/servers/@georgeck/hn-companion-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@georgeck/hn-companion-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@georgeck/hn-companion-mcp/badge" alt="Hacker News Companion MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.